### PR TITLE
feat: Google 번역 API를 이용한 신규 번역 기능 추가

### DIFF
--- a/src/main/java/com/busanit501/translationproject/config/SecurityConfig.java
+++ b/src/main/java/com/busanit501/translationproject/config/SecurityConfig.java
@@ -15,7 +15,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable()) // CSRF 보호 비활성화 (REST API의 경우)
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/api/paraphrase/**").permitAll() // 해당 경로는 인증 없이 허용
+                        .requestMatchers("/api/paraphrase/**", "/api/translate/**").permitAll() // 해당 경로는 인증 없이 허용
                         .anyRequest().authenticated() // 나머지 모든 요청은 인증 필요
                 );
         return http.build();

--- a/src/main/java/com/busanit501/translationproject/controller/ParaphraseController.java
+++ b/src/main/java/com/busanit501/translationproject/controller/ParaphraseController.java
@@ -1,7 +1,7 @@
 package com.busanit501.translationproject.controller;
 
-import com.busanit501.react_project.dto.ParaphraseRequest;
-import com.busanit501.react_project.service.ParaphraseService;
+import com.busanit501.translationproject.dto.ParaphraseRequest;
+import com.busanit501.translationproject.service.ParaphraseService;
 import org.json.JSONException;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/busanit501/translationproject/controller/TranslateController.java
+++ b/src/main/java/com/busanit501/translationproject/controller/TranslateController.java
@@ -1,0 +1,26 @@
+package com.busanit501.translationproject.controller;
+
+import com.busanit501.translationproject.dto.TranslateRequest;
+import com.busanit501.translationproject.dto.TranslateResponse;
+import com.busanit501.translationproject.service.TranslateService;
+import org.json.JSONException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/translate")
+public class TranslateController {
+
+    private final TranslateService translateService;
+
+    public TranslateController(TranslateService translateService) {
+        this.translateService = translateService;
+    }
+
+    @PostMapping
+    public ResponseEntity<TranslateResponse> translateText(@RequestBody TranslateRequest request) throws JSONException {
+        String translatedText = translateService.translate(request.getText(), request.getSourceLang(), request.getTargetLang());
+        TranslateResponse response = new TranslateResponse(translatedText);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/busanit501/translationproject/dto/TranslateRequest.java
+++ b/src/main/java/com/busanit501/translationproject/dto/TranslateRequest.java
@@ -1,0 +1,14 @@
+package com.busanit501.translationproject.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TranslateRequest {
+    private String text;
+    private String sourceLang;
+    private String targetLang;
+}

--- a/src/main/java/com/busanit501/translationproject/dto/TranslateResponse.java
+++ b/src/main/java/com/busanit501/translationproject/dto/TranslateResponse.java
@@ -1,0 +1,12 @@
+package com.busanit501.translationproject.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TranslateResponse {
+    private String translatedText;
+}

--- a/src/main/java/com/busanit501/translationproject/service/TranslateService.java
+++ b/src/main/java/com/busanit501/translationproject/service/TranslateService.java
@@ -1,0 +1,59 @@
+package com.busanit501.translationproject.service;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+public class TranslateService {
+
+    @Value("${google.api.key}")
+    private String apiKey;
+
+    private static final String GOOGLE_TRANSLATE_URL = "https://translation.googleapis.com/language/translate/v2";
+
+    public String translate(String text, String sourceLang, String targetLang) throws JSONException {
+        RestTemplate restTemplate = new RestTemplate();
+
+        // 1. Build the URL with the API key
+        String url = UriComponentsBuilder.fromHttpUrl(GOOGLE_TRANSLATE_URL)
+                .queryParam("key", apiKey)
+                .toUriString();
+
+        // 2. Create the request body
+        JSONObject requestBody = new JSONObject();
+        requestBody.put("q", text);
+        requestBody.put("source", sourceLang);
+        requestBody.put("target", targetLang);
+        requestBody.put("format", "text");
+
+        // 3. Set headers
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        // 4. Create the HTTP entity
+        HttpEntity<String> entity = new HttpEntity<>(requestBody.toString(), headers);
+
+        // 5. Make the API call
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.POST, entity, String.class);
+
+            if (response.getStatusCode() == HttpStatus.OK) {
+                // 6. Parse the response
+                JSONObject responseJson = new JSONObject(response.getBody());
+                return responseJson.getJSONObject("data")
+                                   .getJSONArray("translations")
+                                   .getJSONObject(0)
+                                   .getString("translatedText");
+            } else {
+                return "Error: Google API returned status code " + response.getStatusCode() + " Body: " + response.getBody();
+            }
+        } catch (Exception e) {
+            return "Error during API call: " + e.getMessage();
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,6 +9,8 @@ spring.datasource.password=webuser
 # OpenAI API Key
 openai.api.key=${OPENAI_API_KEY}
 
+google.api.key=${GOOGLE_API_KEY}
+
 # OpenAI ?? (Paraphrase ?)
 openai.model=gpt-3.5-turbo
 


### PR DESCRIPTION
 - 기존 Paraphrase 기능 외에, Google Cloud Translation API (v2)를 연동하여 새로운 서버사이드 번역        
     기능을 추가했습니다.
   - 사용자는 POST /api/translate 엔드포인트를 통해 텍스트 번역을 요청할 수 있습니다.
  
 1. 신규 번역 기능 추가 (`Translate`)
   - TranslateController: /api/translate 요청을 처리하는 컨트롤러를 추가했습니다.
   - TranslateService: Google Translate API(v2)를 호출하여 실제 번역 로직을 수행하는 서비스를
     구현했습니다.
   - TranslateRequest, TranslateResponse: 번역 요청 및 응답에 사용되는 DTO(Data Transfer Object)를
     추가했습니다.
 2. 보안 설정 업데이트
   - SecurityConfig.java: 새로 추가된 /api/translate/** 경로에 대해 모든 사용자가 접근할 수 있도록
     권한을 허용하여 403 오류를 해결했습니다.

  3. 설정 파일 업데이트
   - application.properties: Google API 키를 환경 변수(GOOGLE_API_KEY)로부터 받을 수 있도록 설정을
     추가했습니다.


