### PR TITLE
 feat: 사용자 프로필 API 구현 및 멤버 서비스 통합

### DIFF
--- a/src/main/java/com/busanit501/translationproject/controller/MemberController.java
+++ b/src/main/java/com/busanit501/translationproject/controller/MemberController.java
@@ -1,9 +1,13 @@
 package com.busanit501.translationproject.controller;
 
+import com.busanit501.translationproject.dto.MemberDTO;
+import com.busanit501.translationproject.service.MemberService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -11,12 +15,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/member")
 @Log4j2
+@RequiredArgsConstructor
 public class MemberController {
+
+    private final MemberService memberService;
 
     @Tag(name = "멤버 토큰 테스트", description = "멤버 토큰 활성화 테스트")
     @GetMapping("/me")
     @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
-    public Boolean me(){
-        return true;
+    public MemberDTO me(){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String memberId = authentication.getName(); // Get the username (memberId) from the authenticated principal
+        log.info("Authenticated memberId: " + memberId);
+        return memberService.getMember(memberId);
     }
 }

--- a/src/main/java/com/busanit501/translationproject/repository/MemberRepository.java
+++ b/src/main/java/com/busanit501/translationproject/repository/MemberRepository.java
@@ -3,6 +3,9 @@ package com.busanit501.translationproject.repository;
 import com.busanit501.translationproject.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, String> {
     boolean existsByMemberId(String memberId);
+    Optional<Member> findByMemberId(String memberId);
 }

--- a/src/main/java/com/busanit501/translationproject/service/MemberService.java
+++ b/src/main/java/com/busanit501/translationproject/service/MemberService.java
@@ -8,5 +8,6 @@ public interface MemberService {
     boolean isRegistered(String memberId);
     void join(MemberDTO memberDTO);
     boolean checkId(String memberId);
+    MemberDTO getMember(String memberId);
 }
 

--- a/src/main/java/com/busanit501/translationproject/service/MemberServiceImpl.java
+++ b/src/main/java/com/busanit501/translationproject/service/MemberServiceImpl.java
@@ -77,4 +77,15 @@ public class MemberServiceImpl implements MemberService{
         // memberId가 존재하면 true 반환(중복), 존재하지 않으면 false반환(사용가능)
         return memberRepository.existsByMemberId(memberId);
     }
+
+    @Override
+    public MemberDTO getMember(String memberId) {
+        return memberRepository.findByMemberId(memberId)
+                .map(member -> new MemberDTO(
+                        member.getMemberId(),
+                        member.getUserName(),
+                        member.getEmail(),
+                        member.getPassword()))
+                .orElse(null);
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,7 @@ spring.datasource.password=webuser
 #spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 
 # OpenAI API Key
-openai.api.key=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
+openai.api.key=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
 
 google.api.key=AIzaSyCVRAVTCQXdiB-rHtxNkhyxUeTjK3kJCV0
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,12 +7,12 @@ spring.datasource.password=webuser
 #spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 
 # OpenAI API Key
-#openai.api.key=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
+openai.api.key=${open.api}
 
-#.api.key=AIzaSyCVRAVTCQXdiB-rHtxNkhyxUeTjK3kJCV0
+.api.key=${open.api}
 
 # OpenAI ?? (Paraphrase ?)
-#openai.model=gpt-3.5-turbo
+openai.model=gpt-3.5-turbo
 
 # Hibernate settings for MariaDB
 #spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect
@@ -25,4 +25,4 @@ logging.level.org.springframework=info
 logging.level.com.busanit501=debug
 logging.level.org.springframework.security=debug
 
-com.busanit5012.jwt.secret=wowwowthisisTeamProjectLegendTeamActuallyjookindarealzzz
+com.busanit5012.jwt.secret=${open.api}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,12 +7,12 @@ spring.datasource.password=webuser
 #spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 
 # OpenAI API Key
-openai.api.key=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
+#openai.api.key=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
 
-google.api.key=AIzaSyCVRAVTCQXdiB-rHtxNkhyxUeTjK3kJCV0
+#.api.key=AIzaSyCVRAVTCQXdiB-rHtxNkhyxUeTjK3kJCV0
 
 # OpenAI ?? (Paraphrase ?)
-openai.model=gpt-3.5-turbo
+#openai.model=gpt-3.5-turbo
 
 # Hibernate settings for MariaDB
 #spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect


### PR DESCRIPTION
 - **MemberRepository:** memberId로 사용자를 찾을 수 있는 findByMemberId 메서드를 추가했습니다.
 - **MemberService:** memberId를 기반으로 MemberDTO를 검색하는 getMember 메서드를 추가했습니다.
 - **MemberServiceImpl:** MemberService의 getMember 메서드를 구현하여 Member 엔티티를 MemberDTO로 변환합니다.
 - **MemberController:** /api/member/me 엔드포인트를 수정하여 인증된 사용자의 MemberDTO를 반환하도록 변경했습니다. 이를 통해 프론트엔드에서 사용자 이름(userName)과 같은 상세 정보를 가져올 수 있습니다.